### PR TITLE
Fixes to missing action and minor improvement to empty dir action

### DIFF
--- a/actions/declare_missing.py
+++ b/actions/declare_missing.py
@@ -6,7 +6,7 @@ from rucio_consistency import Stats
 from run import CCRun
 from config import ActionConfiguration
 
-Version = "1.4"
+Version = "1.5"
 
 Usage = """
 python declare_missing.py [options] <storage_path> <scope> <rse>
@@ -87,12 +87,14 @@ def missing_action(storage_dir, rse, scope, max_age_last, out, stats, stats_key,
             aborted_reason = "no files found by the scanner"
             print("No files found by the scanner -- aborting action")
             abort = True
-        elif not num_expected:
+        elif num_expected is None:
             aborted_reason = "can not estimate the number of expected files"
             print("No estimate for the number of expected files -- aborting action")
             abort = True
         else:
-            ratio = missing_count/num_expected
+            ratio = 0
+            if num_expected > 0:
+                ratio = missing_count/num_expected
             print("Missing replicas:", missing_count, "  expected:", num_expected, "  ratio:", "%.2f%%" % (ratio*100.0,))
             if ratio > fraction:
                 abort = True

--- a/actions/remove_empty_dirs.py
+++ b/actions/remove_empty_dirs.py
@@ -247,7 +247,7 @@ def empty_action(storage_path, rse, out, lfn_converter, stats, stats_key, dry_ru
             confirmed = set(lfn_converter.lfn_or_path_to_path(path) for path in recent_runs[0].empty_directories())
             confirmed = update_confirmed(confirmed, set(lfn_converter.lfn_or_path_to_path(path) for path in recent_runs[-1].empty_directories()))
             for run in recent_runs[1:-1]:
-                print(f"run: {run} - #confirmed: {len(confirmed)}")
+                print(f"run: {run.Run} - #confirmed: {len(confirmed)}")
                 if not confirmed:
                     break
                 run_set = set(lfn_converter.lfn_or_path_to_path(path) for path in run.empty_directories())


### PR DESCRIPTION
These changes to missing action fix a crash in the missing_action processing, caused by incorrect type and in the missing ratio calculation.
There is also a minor fix to empty_action, to print the proper run.Run (timestamp) string rather than the python class description.