### PR TITLE
Add -L switch (permanently lost files) to declare_missing.py call

### DIFF
--- a/actions/declare_missing.py
+++ b/actions/declare_missing.py
@@ -154,7 +154,7 @@ def missing_action(storage_dir, rse, scope, max_age_last, out, stats, stats_key,
                     my_stats["permanently_lost_files"] = len(lost_files)
                     if outLost is not None:
                         lost_files_to_write = '\n'.join(str(item) for item in lost_files)
-                       	outLost.write(lost_files_to_write)
+                        outLost.write(lost_files_to_write)
                         if outLost is not sys.stdout:
                             outLost.close()
                 except Exception as e:

--- a/site_cmp3/site_cmp3.sh
+++ b/site_cmp3/site_cmp3.sh
@@ -205,7 +205,14 @@ echo Missing files ...
 echo
 missing_action_errors=${out}/${RSE}_${now}_missing_action.errors
 m_action_list=${out}/${RSE}_${now}_M_action.list
-$python actions/declare_missing.py -a root -o ${m_action_list} -c ${merged_config_file} -s $stats $out $scope $RSE 2>> ${missing_action_errors}
+perm_lost_list=${out}/${RSE}_${now}_permLost.list
+$python actions/declare_missing.py \
+  -a root \
+  -o ${m_action_list} \
+  -c ${merged_config_file} \
+  -s $stats \
+  -L ${perm_lost_list} \
+  $out $scope $RSE 2>> ${missing_action_errors}
 
 echo
 echo Dark files ...


### PR DESCRIPTION
This is a follow-up to [PR #13](https://github.com/dmwm/cms_consistency/pull/13).

The -L switch forces the writing of a list containing any permanently lost files to the consistency-dump area.  The file name follows the usual $RSE_$now_permLost.list standard.
