### PR TITLE
Updates for consistency image (tag 4.8.9)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install -y https://repo.opensciencegrid.org/osg/25-main/osg-25-main-el9-
     dnf install -y osg-pki-tools voms voms-clients-cpp \
       xrootd-libs xrootd-client \
       python3 python3-pip \
-      git which diffutils cronie crontabs libaio && \
+      git which diffutils cronie-noanacron libaio && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,22 +17,17 @@ RUN dnf install -y https://repo.opensciencegrid.org/osg/25-main/osg-25-main-el9-
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# Oracle client
+#.. Oracle client
 # depends on libaio
 RUN rpm -i https://yum.oracle.com/repo/OracleLinux/OL8/oracle/instantclient21/x86_64/getPackage/oracle-instantclient-basic-21.20.0.0.0-1.el8.x86_64.rpm
 
-# jobber
+#.. jobber -- obsolete, soon to be removed
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.4/jobber-1.4.4-1.el8.x86_64.rpm
 
-# crypto policies
+#.. crypto policies
 RUN update-crypto-policies --set DEFAULT:SHA1
 
-# Python and libs
-RUN dnf install -y python3 python3-pip \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
-
-
+#.. pip3-installed stuff
 RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install SQLAlchemy pyyaml pythreader cx_Oracle j2cli
 RUN pip3 install --no-cache-dir --pre rucio[oracle,mysql,postgresql]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf install -y https://repo.opensciencegrid.org/osg/24-main/osg-24-main-el9-
 
 # Oracle client
 # depends on libaio
-RUN rpm -i https://yum.oracle.com/repo/OracleLinux/OL8/oracle/instantclient21/x86_64/getPackage/oracle-instantclient-basic-21.14.0.0.0-1.el8.x86_64.rpm
+RUN rpm -i https://yum.oracle.com/repo/OracleLinux/OL8/oracle/instantclient21/x86_64/getPackage/oracle-instantclient-basic-21.20.0.0.0-1.el8.x86_64.rpm
 
 # jobber
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.4/jobber-1.4.4-1.el8.x86_64.rpm
@@ -28,13 +28,12 @@ RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.4/jobber-1.
 RUN update-crypto-policies --set DEFAULT:SHA1
 
 # Python and libs
-RUN dnf install -y python3 python3-pip git \
+RUN dnf install -y python3 python3-pip \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
 
 RUN pip3 install --upgrade pip
-#RUN pip3 install --upgrade setuptools
 RUN pip3 --no-cache-dir install SQLAlchemy pyyaml pythreader cx_Oracle j2cli
 RUN pip3 install --no-cache-dir --pre rucio[oracle,mysql,postgresql]
 RUN pip3 install rucio-clients rucio-consistency

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y update \
 # PKI stuff
 # xrootd client
 # Python and libs
-RUN dnf install -y https://repo.opensciencegrid.org/osg/24-main/osg-24-main-el9-release-latest.rpm && \
+RUN dnf install -y https://repo.opensciencegrid.org/osg/25-main/osg-25-main-el9-release-latest.rpm && \
     dnf install -y osg-pki-tools voms voms-clients-cpp \
       xrootd-libs xrootd-client \
       python3 python3-pip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,19 @@
 FROM almalinux:9
 USER root
 
-RUN dnf install -y epel-release.noarch\
+RUN dnf -y update \
+    && dnf install -y epel-release.noarch \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
 # PKI stuff
 # xrootd client
 # Python and libs
-RUN dnf install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el9-release-latest.rpm && \
+RUN dnf install -y https://repo.opensciencegrid.org/osg/24-main/osg-24-main-el9-release-latest.rpm && \
     dnf install -y osg-pki-tools voms voms-clients-cpp \
-    xrootd-libs xrootd-client \
-    python3 python3-pip git \
-    which diffutils \ 
-    libaio && \
+      xrootd-libs xrootd-client \
+      python3 python3-pip \
+      git which diffutils cronie crontabs libaio && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
@@ -31,6 +31,7 @@ RUN update-crypto-policies --set DEFAULT:SHA1
 RUN dnf install -y python3 python3-pip git \
     && dnf clean all \
     && rm -rf /var/cache/dnf
+
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --upgrade setuptools
@@ -58,3 +59,4 @@ RUN chmod +x *.sh
 RUN git clone https://github.com/dmwm/cms_consistency.git
 
 CMD /bin/bash
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN dnf install -y python3 python3-pip git \
 
 
 RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
+#RUN pip3 install --upgrade setuptools
 RUN pip3 --no-cache-dir install SQLAlchemy pyyaml pythreader cx_Oracle j2cli
 RUN pip3 install --no-cache-dir --pre rucio[oracle,mysql,postgresql]
 RUN pip3 install rucio-clients rucio-consistency

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CONSISTENCY_VERSION=4.8.7
+export CONSISTENCY_VERSION=4.8.9
 
 export HARBOR=registry.cern.ch/cmsrucio
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export CONSISTENCY_VERSION=4.8.4
+export CONSISTENCY_VERSION=4.8.5b
 
 export HARBOR=registry.cern.ch/cmsrucio
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export CONSISTENCY_VERSION=4.5.1
+export CONSISTENCY_VERSION=4.8.4
 
 export HARBOR=registry.cern.ch/cmsrucio
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-#set -e
-
 export CONSISTENCY_VERSION=4.8.5
 
 export HARBOR=registry.cern.ch/cmsrucio

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-set -e
+#set -e
 
-export CONSISTENCY_VERSION=4.8.5c
+export CONSISTENCY_VERSION=4.8.5
 
 export HARBOR=registry.cern.ch/cmsrucio
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CONSISTENCY_VERSION=4.8.5
+export CONSISTENCY_VERSION=4.8.6a
 
 export HARBOR=registry.cern.ch/cmsrucio
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export CONSISTENCY_VERSION=4.8.5b
+export CONSISTENCY_VERSION=4.8.5c
 
 export HARBOR=registry.cern.ch/cmsrucio
 


### PR DESCRIPTION
This PR updates the Dockerfile and version for the new consistency image. 
These are the changes for consistency image v4.8.7:

- based on almalinux:9
- OSG upgraded from 3.6 to 25-main installed
- cronie_noanacron installed
- could not yet upgrade to almalinux:10 and OSG 25-main because the latter depends on m2crypto, which is not yet properly packaged for almalinux:10.