### PR TITLE
Update version in consistency image build script

### DIFF
--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export CONSISTENCY_VERSION=4.5.1
+export CONSISTENCY_VERSION=4.8.7
 
 export HARBOR=registry.cern.ch/cmsrucio
 


### PR DESCRIPTION
CMS rucio consistency image tag is updated to "release-4.8.7" in the `docker/build-image.sh` script.