### PR TITLE
 New con-mon web server image - tagged 2.1.3

### DIFF
--- a/monitor/server/Dockerfile
+++ b/monitor/server/Dockerfile
@@ -12,16 +12,12 @@ RUN uv venv .venv && \
     . .venv/bin/activate && \
     uv pip install --no-cache-dir --python .venv/bin/python webpie pythreader jinja2 legacy-cgi
 
-# 4. Prepare app environment as needed
-ADD start.sh /app/start.sh
-RUN mkdir app samples
-
 
 # === STAGE 2: RUNNER (The minimal, clean production image) ===
 FROM python:3.14-slim as runner
 
 # 1. Setup environment
-WORKDIR /app
+WORKDIR /
 ENV PATH="/app/.venv/bin:$PATH"
 
 #### 2. Interactive mode only (to be removed for the production image): ######
@@ -38,16 +34,21 @@ ENV PATH="/app/.venv/bin:$PATH"
 # 3. Copy the *clean virtual environment* and application files from the builder stage
 #    This drastically reduces the size of the final image by excluding build tools and cache
 COPY --from=builder app /app/
-ADD app ./app
+ADD app /app
+ADD start.sh /app/start.sh
+
+#.. start.sh was moved from /root to /app some commits ago. This restores backward compatibility
+RUN ln -sf /app/start.sh /root/start.sh
 
 # 4. Final setup
 EXPOSE 8400
+
 RUN mkdir -p /var/cache/consistency-dump /var/cache/consistency-temp /reports/unmerged \
-    && chmod +x *.sh
+    && chmod +x /app/start.sh
 
 # 5. Define how the container starts - enable EITHER (a) OR (b)
 # a) For production mode: start app right away
-ENTRYPOINT ["/app/start.sh"]
+ENTRYPOINT ["/root/start.sh"]
 
 # b) For interactive / testing mode: comment out the ENTRYPOINT line above
 #CMD [ "/bin/bash", "--login" ]

--- a/monitor/server/build.sh
+++ b/monitor/server/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export MONITOR_VERSION=rucio-con-mon:2.1.2
+export MONITOR_VERSION=rucio-con-mon:2.1.3
 export HARBOR=registry.cern.ch/cmsrucio
 
 podman build -t $HARBOR/$MONITOR_VERSION .

--- a/monitor/server/start.sh
+++ b/monitor/server/start.sh
@@ -7,7 +7,7 @@ WM_DATA=/reports/unmerged
 PATH=/app/.venv/bin:$PATH
 
 python -V
-cd /app
+#cd /app
 
 echo "--- starting server with: " python app/server.py --um-ignore /store/unmerged/logs/ -p 8400 "$@" $CC_DATA $WM_DATA
 python app/server.py --um-ignore /store/unmerged/logs/ -p 8400 "$@" $CC_DATA $WM_DATA

--- a/monitor/server/start.sh
+++ b/monitor/server/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo start.sh: version 2.1.2
+echo start.sh: version 2.1.3
 
 CC_DATA=/reports
 WM_DATA=/reports/unmerged


### PR DESCRIPTION
The new image fixes a bug in previous image, by ensuring that the starting script is found at its new /app/start.sh location, while keeping backward compatibility with a symlink to original location /root/start.sh.
